### PR TITLE
fix(kaniko): quote EXTRA_ARGS to fix multi-destination builds

### DIFF
--- a/kaniko-build/action.yml
+++ b/kaniko-build/action.yml
@@ -66,14 +66,13 @@ runs:
         fi
         echo "DEBUG: EXTRA_ARGS='${EXTRA_ARGS}'"
 
-        # Configure build (use heredoc with <<- to strip leading tabs isn't supported in sh, so use sed)
+        # Configure build - values with spaces must be quoted
         cat > /kaniko-build/env << EOF
-        DOCKERFILE=${KANIKO_DOCKERFILE}
-        DESTINATION=${KANIKO_DESTINATION}
-        NO_PUSH=$([ "${KANIKO_PUSH}" = "true" ] && echo "false" || echo "true")
-        EXTRA_ARGS=${EXTRA_ARGS}
-        EOF
-        sed -i 's/^[[:space:]]*//' /kaniko-build/env
+DOCKERFILE=${KANIKO_DOCKERFILE}
+DESTINATION=${KANIKO_DESTINATION}
+NO_PUSH=$([ "${KANIKO_PUSH}" = "true" ] && echo "false" || echo "true")
+EXTRA_ARGS="${EXTRA_ARGS}"
+EOF
 
         # Trigger and wait
         touch /kaniko-build/trigger


### PR DESCRIPTION
## Summary
- Fixed quoting issue in env file that prevented multi-destination builds from working
- The EXTRA_ARGS value contains spaces (e.g. " --destination=ghcr.io/..."). Without quotes, the shell interpreted this as setting EXTRA_ARGS empty and trying to run the flag as a command

## Test plan
- [x] Added debug logging to verify EXTRA_ARGS is set correctly
- [ ] Merge PR and test multi-destination build in apps.dev-containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)