### PR TITLE
fix(kaniko): use printf for env file to fix YAML parsing and quoting

### DIFF
--- a/kaniko-build/action.yml
+++ b/kaniko-build/action.yml
@@ -66,13 +66,14 @@ runs:
         fi
         echo "DEBUG: EXTRA_ARGS='${EXTRA_ARGS}'"
 
-        # Configure build - values with spaces must be quoted
-        cat > /kaniko-build/env << EOF
-DOCKERFILE=${KANIKO_DOCKERFILE}
-DESTINATION=${KANIKO_DESTINATION}
-NO_PUSH=$([ "${KANIKO_PUSH}" = "true" ] && echo "false" || echo "true")
-EXTRA_ARGS="${EXTRA_ARGS}"
-EOF
+        # Configure build - write env file with printf for proper quoting
+        NO_PUSH_VAL=$([ "${KANIKO_PUSH}" = "true" ] && echo "false" || echo "true")
+        printf 'DOCKERFILE=%s\n' "${KANIKO_DOCKERFILE}" > /kaniko-build/env
+        printf 'DESTINATION=%s\n' "${KANIKO_DESTINATION}" >> /kaniko-build/env
+        printf 'NO_PUSH=%s\n' "${NO_PUSH_VAL}" >> /kaniko-build/env
+        printf 'EXTRA_ARGS="%s"\n' "${EXTRA_ARGS}" >> /kaniko-build/env
+        echo "DEBUG: env file contents:"
+        cat /kaniko-build/env
 
         # Trigger and wait
         touch /kaniko-build/trigger


### PR DESCRIPTION
## Summary
- Replaces heredoc with printf statements for writing env file
- Fixes YAML parsing error from previous commit (unindented heredoc content looked like YAML keys)
- Properly quotes EXTRA_ARGS value so shell sourcing works correctly

## Test plan
- [ ] Verify action loads without YAML errors
- [ ] Test multi-destination build pushes to both tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)