### PR TITLE
feat(kaniko): add layer cache support

### DIFF
--- a/kaniko-build/action.yml
+++ b/kaniko-build/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: 'Registry username'
     required: false
     default: ''
+  cache-repo:
+    description: 'Registry path for layer cache (e.g., ghcr.io/org/repo/cache)'
+    required: false
+    default: ''
 
 runs:
   using: 'composite'
@@ -43,6 +47,7 @@ runs:
         KANIKO_PUSH: ${{ inputs.push }}
         KANIKO_TOKEN: ${{ inputs.registry-token }}
         KANIKO_USER: ${{ inputs.registry-user }}
+        KANIKO_CACHE_REPO: ${{ inputs.cache-repo }}
       run: |
         # Prepare build directory
         rm -rf /kaniko-build/*
@@ -70,6 +75,7 @@ runs:
         printf 'DESTINATION=%s\n' "${KANIKO_DESTINATION}" >> /kaniko-build/env
         printf 'NO_PUSH=%s\n' "${NO_PUSH_VAL}" >> /kaniko-build/env
         printf 'EXTRA_ARGS="%s"\n' "${EXTRA_ARGS}" >> /kaniko-build/env
+        printf 'CACHE_REPO=%s\n' "${KANIKO_CACHE_REPO}" >> /kaniko-build/env
 
         # Trigger and wait
         touch /kaniko-build/trigger


### PR DESCRIPTION
## Summary
- Add `cache-repo` input for Kaniko layer caching
- When specified, Kaniko stores/retrieves layer cache from the registry
- Significantly speeds up subsequent builds by reusing unchanged layers

## Usage
```yaml
- uses: labrats-work/actions.common/kaniko-build@main
  with:
    context: src
    destination: ghcr.io/org/repo:tag
    cache-repo: ghcr.io/org/repo/cache
    registry-token: ${{ secrets.GITHUB_TOKEN }}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)